### PR TITLE
Refactor build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,16 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const lib_extension = if (builtin.target.os.tag == .macos) ".dylib" else ".so";
+const exe_extension = if (builtin.target.os.tag == .windows) ".exe" else "";
+const name = "example";
 pub fn build(b: *std.build.Builder) !void {
+    const pdx_file_name = name ++ ".pdx";
     const optimize = b.standardOptimizeOption(.{});
 
-    const pdx_file_name = "example.pdx";
+    const writer = b.addWriteFiles();
+    const source_dir = writer.getDirectorySource();
+    writer.step.name = "write source directory";
 
     const lib = b.addSharedLibrary(.{
         .name = "pdex",
@@ -12,84 +18,63 @@ pub fn build(b: *std.build.Builder) !void {
         .optimize = optimize,
         .target = .{},
     });
-
-    const output_path = "Source";
-    const lib_step = b.addInstallArtifact(lib);
-    lib_step.dest_dir = .{ .custom = output_path };
+    _ = writer.addCopyFile(lib.getOutputSource(), "pdex" ++ lib_extension);
 
     const playdate_target = try std.zig.CrossTarget.parse(.{
         .arch_os_abi = "thumb-freestanding-eabihf",
         .cpu_features = "cortex_m7-fp64-fp_armv8d16-fpregs64-vfp2-vfp3d16-vfp4d16",
     });
-    const game_elf = b.addExecutable(.{
+    const elf = b.addExecutable(.{
         .name = "pdex.elf",
         .root_source_file = .{ .path = "src/main.zig" },
         .target = playdate_target,
         .optimize = optimize,
     });
-    game_elf.step.dependOn(&lib_step.step);
-    game_elf.force_pic = true;
-    game_elf.link_emit_relocs = true;
-    game_elf.setLinkerScriptPath(.{ .path = "link_map.ld" });
-    const game_elf_step = b.addInstallArtifact(game_elf);
-    game_elf_step.dest_dir = .{ .custom = output_path };
+    elf.force_pic = true;
+    elf.link_emit_relocs = true;
+    elf.setLinkerScriptPath(.{ .path = "link_map.ld" });
     if (optimize == .ReleaseFast) {
-        game_elf.omit_frame_pointer = true;
+        elf.omit_frame_pointer = true;
+    }
+    _ = writer.addCopyFile(elf.getOutputSource(), "pdex.elf");
+
+    // WriteFile doesn't support copying whole directories.
+    var assets = try b.build_root.handle.openIterableDir("assets", .{});
+    defer assets.close();
+    var iter = assets.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .file) continue;
+        const file_source = .{ .path = b.pathJoin(&.{ "assets", entry.name }) };
+        _ = writer.addCopyFile(file_source, entry.name);
     }
 
     const playdate_sdk_path = try std.process.getEnvVarOwned(b.allocator, "PLAYDATE_SDK_PATH");
+    const pdc_path = b.pathJoin(&.{ playdate_sdk_path, "bin", "pdc" ++ exe_extension });
+    const pd_simulator_path = b.pathJoin(&.{ playdate_sdk_path, "bin", "PlaydateSimulator" ++ exe_extension });
 
-    var previous_step = &game_elf_step.step;
-    if (remove_lib_prefix_step(b)) |step| {
-        step.step.dependOn(&game_elf_step.step);
-        previous_step = &step.step;
-    }
-    const copy_assets = b.addSystemCommand(&.{ "cp", "assets/playdate_image.png", "assets/pdxinfo", "assets/icon.png", "zig-out/Source" });
-    copy_assets.step.dependOn(previous_step);
-    const pdc_path = try std.fmt.allocPrint(b.allocator, "{s}/bin/pdc{s}", .{
-        playdate_sdk_path,
-        if (builtin.target.os.tag == .windows) ".exe" else "",
+    const pdc = b.addSystemCommand(&.{ pdc_path, "--skip-unknown" });
+    pdc.addDirectorySourceArg(source_dir);
+    pdc.setName("pdc" ++ exe_extension);
+    const pdx = pdc.addOutputFileArg(pdx_file_name);
+
+    b.installDirectory(.{
+        .source_dir = pdx,
+        .install_dir = .prefix,
+        .install_subdir = pdx_file_name,
     });
-    const pdc = b.addSystemCommand(&.{ pdc_path, "--skip-unknown", "zig-out/Source", "zig-out/" ++ pdx_file_name });
-    pdc.step.dependOn(&copy_assets.step);
-    b.getInstallStep().dependOn(&pdc.step);
 
-    const run_cmd = b: {
-        switch (builtin.target.os.tag) {
-            .windows => {
-                const pd_simulator_path = try std.fmt.allocPrint(b.allocator, "{s}/bin/PlaydateSimulator.exe", .{playdate_sdk_path});
-                break :b b.addSystemCommand(&.{ pd_simulator_path, "zig-out/" ++ pdx_file_name });
-            },
-            .macos => {
-                break :b b.addSystemCommand(&.{ "open", "zig-out/" ++ pdx_file_name });
-            },
-            .linux => {
-                const pd_simulator_path = try std.fmt.allocPrint(b.allocator, "{s}/bin/PlaydateSimulator", .{playdate_sdk_path});
-                break :b b.addSystemCommand(&.{ pd_simulator_path, "zig-out/" ++ pdx_file_name });
-            },
-            else => {
-                @panic("Unsupported OS!");
-            },
-        }
-    };
-    run_cmd.step.dependOn(&pdc.step);
+    const run_cmd = b.addSystemCommand(&.{pd_simulator_path});
+    run_cmd.setName("PlaydateSimulator");
+    run_cmd.addDirectorySourceArg(pdx);
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
     //clean step
     {
         const clean_step = b.step("clean", "Clean all artifacts");
-        const rm_zig_cache = b.addRemoveDirTree("zig-cache");
+        const rm_zig_cache = b.addRemoveDirTree(b.cache_root.path orelse ".");
         clean_step.dependOn(&rm_zig_cache.step);
-        const rm_zig_out = b.addRemoveDirTree("zig-out");
+        const rm_zig_out = b.addRemoveDirTree(b.getInstallPath(.prefix, ""));
         clean_step.dependOn(&rm_zig_out.step);
     }
-}
-
-fn remove_lib_prefix_step(b: *std.build.Builder) ?*std.build.Step.Run {
-    const extension = if (builtin.target.os.tag == .macos) "dylib" else "so";
-    return switch (builtin.target.os.tag) {
-        .macos, .linux => b.addSystemCommand(&.{ "mv", "zig-out/Source/libpdex." ++ extension, "zig-out/Source/pdex." ++ extension }),
-        else => null,
-    };
 }

--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,12 @@ pub fn build(b: *std.build.Builder) !void {
         .optimize = optimize,
         .target = .{},
     });
-    _ = writer.addCopyFile(lib.getOutputSource(), "pdex" ++ if (os_tag == .macos) ".dylib" else ".so");
+    _ = writer.addCopyFile(lib.getOutputSource(), "pdex" ++ switch (os_tag) {
+        .windows => ".dll",
+        .macos => ".dylib",
+        .linux => ".so",
+        else => @panic("Unsupported OS"),
+    });
 
     const playdate_target = try std.zig.CrossTarget.parse(.{
         .arch_os_abi = "thumb-freestanding-eabihf",

--- a/build.zig
+++ b/build.zig
@@ -71,6 +71,7 @@ pub fn build(b: *std.build.Builder) !void {
     run_cmd.setName("PlaydateSimulator");
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+    run_step.dependOn(b.getInstallStep());
 
     const clean_step = b.step("clean", "Clean all artifacts");
     clean_step.dependOn(b.getUninstallStep());


### PR DESCRIPTION
Removes uses of system commands, and makes use of FileSource. This cleans up platform specific code, allows installing to any prefix, and tidies up the install directory by ommitting the Source directory.