### PR TITLE
Add nix shell + overlay to automatically install playdate compiler

### DIFF
--- a/nix/playdate-sdk/overlay.nix
+++ b/nix/playdate-sdk/overlay.nix
@@ -1,0 +1,20 @@
+let
+  # this was taken from a gist which involved cross compilation. This is probably a weird thing to do.
+  pkgsIntel = import <nixpkgs> {};
+in
+  final: prev: rec {
+    inherit pkgsIntel;
+
+    # This always outputs x86_64 binaries. I setup binfmt_misc in my 
+    # system config to run x86_64 binaries on aarch64 via qemu. This
+    # package properly patches all the binaries so they have the right
+    # x86_64 libs and linker cross-compiled so they'll just work if
+    # you have binfmt_misc setup.
+    playdate-sdk = prev.callPackage ./playdate-sdk.nix {};
+
+    # Playdate requires gcc-arm-embedded v11. I haven't tested with later
+    # versions but earlier versions do NOT work. At the time of gisting,
+    # stable is 22.05 and only has gcc-arm-embedded v10. I overlay 
+    # nixpkgs-unstable to get v11.
+    gcc-arm-embedded = final.pkgs-unstable.gcc-arm-embedded-11;
+  }

--- a/nix/playdate-sdk/overlay.nix
+++ b/nix/playdate-sdk/overlay.nix
@@ -4,17 +4,6 @@ let
 in
   final: prev: rec {
     inherit pkgsIntel;
-
-    # This always outputs x86_64 binaries. I setup binfmt_misc in my 
-    # system config to run x86_64 binaries on aarch64 via qemu. This
-    # package properly patches all the binaries so they have the right
-    # x86_64 libs and linker cross-compiled so they'll just work if
-    # you have binfmt_misc setup.
     playdate-sdk = prev.callPackage ./playdate-sdk.nix {};
-
-    # Playdate requires gcc-arm-embedded v11. I haven't tested with later
-    # versions but earlier versions do NOT work. At the time of gisting,
-    # stable is 22.05 and only has gcc-arm-embedded v10. I overlay 
-    # nixpkgs-unstable to get v11.
     gcc-arm-embedded = final.pkgs-unstable.gcc-arm-embedded-11;
   }

--- a/nix/playdate-sdk/playdate-sdk.nix
+++ b/nix/playdate-sdk/playdate-sdk.nix
@@ -4,8 +4,6 @@
   fetchurl,
   pkgsIntel,
 }: let
-  # TODO: eventually, I want to do a check here if we're natively
-  # on x86_64 to not cross-compile these and just use the built-ins.
 
   # Build inputs for `pdc`
   pdcInputs = with pkgsIntel; [

--- a/nix/playdate-sdk/playdate-sdk.nix
+++ b/nix/playdate-sdk/playdate-sdk.nix
@@ -1,0 +1,82 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pkgsIntel,
+}: let
+  # TODO: eventually, I want to do a check here if we're natively
+  # on x86_64 to not cross-compile these and just use the built-ins.
+
+  # Build inputs for `pdc`
+  pdcInputs = with pkgsIntel; [
+    stdenv.cc.cc.lib
+    libpng
+    zlib
+  ];
+
+  # Build inputs for the simulator (excluding those from pdc)
+  pdsInputs = with pkgsIntel; [
+    udev
+    gtk3
+    pango
+    cairo
+    gdk-pixbuf
+    glib
+    webkitgtk
+    xorg.libX11
+    stdenv.cc.cc.lib
+    libxkbcommon
+    wayland
+    SDL2.dev
+  ];
+
+  # For native, if and when we support that:
+  # "$(cat $NIX_CC/nix-support/dynamic-linker)"
+  dynamicLinker = "${pkgsIntel.glibc}/lib/ld-linux-x86-64.so.2";
+in
+  stdenv.mkDerivation rec {
+    pname = "playdate_sdk";
+    version = "2.0.3";
+
+    src = fetchurl {
+      url = "https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-${version}.tar.gz";
+      sha256 = "sha256-FNzb3OjXGZpTTuR9+ox9KZD0sKlYfoA7jg48lZeQrpE=";
+    };
+
+    buildInputs = pdcInputs;
+
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      # Get our new root
+      root=$out/opt/playdate-sdk-${version}
+
+      # Everything else
+      mkdir -p $out/opt/playdate-sdk-${version}
+      cp -r ./ $out/opt/playdate-sdk-${version}
+      ln -s $root $out/opt/playdate-sdk
+
+      # Setup dependencies and interpreter
+      patchelf \
+        --set-interpreter "${dynamicLinker}" \
+        --set-rpath "${lib.makeLibraryPath pdcInputs}" \
+        $root/bin/pdc
+      patchelf \
+        --set-interpreter "${dynamicLinker}" \
+        $root/bin/pdutil
+      patchelf \
+        --set-interpreter "${dynamicLinker}" \
+        --set-rpath "${lib.makeLibraryPath pdsInputs}"\
+        $root/bin/PlaydateSimulator
+
+      # Binaries
+      mkdir -p $out/bin
+      cp $root/bin/pdc $out/bin/pdc
+      cp $root/bin/pdutil $out/bin/pdutil
+      cp $root/bin/PlaydateSimulator $out/bin/PlaydateSimulator
+
+      runHook postInstall
+    '';
+  }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> { overlays = [ (import ./nix/playdate-sdk/overlay.nix) ]; } }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages; [ zig playdate-sdk ];
+    shellHook = ''
+      export PLAYDATE_SDK_PATH="${pkgs.playdate-sdk.outPath}"
+    '';
+}


### PR DESCRIPTION
This is a couple .nix files I modified from a gist https://gist.github.com/mitchellh/450cecda9477fa0d7bb2c72f1b672928 which will automatically pull down and set up the playdate sdk (currently version 2.0.3) for nix users. I have my own fork, but if anyone else would be interested I'd like to get this merged in. With nix installed you can now do
```
git clone https://github.com/DanB91/Zig-Playdate-Template
cd Zig-Playdate-Template
nix-shell
```
and it will automatically pull down and install Playdate SDK, its dependencies, and set up the PLAYDATE_SDK_PATH without a full system install.