### PR TITLE
Exclude .sentry-native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zig-cache
 .vscode
 *.swp
 .DS_Store
+.sentry-native


### PR DESCRIPTION
.sentry-native is generated automatically by the playdate simulator in your project directory, excluding that from repositories