### PR TITLE
fix compilation on windows

### DIFF
--- a/src/playdate_api_definitions.zig
+++ b/src/playdate_api_definitions.zig
@@ -153,7 +153,7 @@ pub const PlaydateSys = extern struct {
 
     //NOTE(Daniel Bokser): std.builtin.VaList is not available when targeting Playdate hardware,
     //      so we need to directly include it
-    const VaList = if (is_compiling_for_playdate_hardware())
+    const VaList = if (is_compiling_for_playdate_hardware() or builtin.os.tag == .windows)
         @cImport({
             @cInclude("stdarg.h");
         }).va_list


### PR DESCRIPTION
[In `std.builtin`,  `VaList` is not allowed due to miscompilations. ](https://github.com/ziglang/zig/blob/a154d8da8e39e5d0ed180b4a1e5150349699e5df/lib/std/builtin.zig#L624)

This is a simple fix to work around the issue.