### PR TITLE
Fixed build with the latest 0.14.0 release

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,7 +59,7 @@ pub fn build(b: *std.Build) !void {
     elf.link_emit_relocs = true;
     elf.entry = .{ .symbol_name = "eventHandler" };
 
-    elf.setLinkerScriptPath(b.path("link_map.ld"));
+    elf.setLinkerScript(b.path("link_map.ld"));
     if (optimize == .ReleaseFast) {
         elf.root_module.omit_frame_pointer = true;
     }
@@ -78,7 +78,7 @@ pub fn build(b: *std.Build) !void {
     };
 
     const pdc = b.addSystemCommand(&.{pdc_path});
-    pdc.addDirectorySourceArg(source_dir);
+    pdc.addDirectoryArg(source_dir);
     pdc.setName("pdc");
     const pdx = pdc.addOutputFileArg(pdx_file_name);
 
@@ -94,7 +94,7 @@ pub fn build(b: *std.Build) !void {
     });
 
     const run_cmd = b.addSystemCommand(&.{pd_simulator_path});
-    run_cmd.addDirectorySourceArg(pdx);
+    run_cmd.addDirectoryArg(pdx);
     run_cmd.setName("PlaydateSimulator");
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
@@ -126,8 +126,8 @@ fn host_or_cross_target(
     force_use_cross_target: bool,
 ) std.Build.ResolvedTarget {
     const result =
-        if (!force_use_cross_target and b.host.result.os.tag == cross_target.os_tag.?)
-        b.host
+        if (!force_use_cross_target and b.graph.host.result.os.tag == cross_target.os_tag.?)
+        b.graph.host
     else
         b.resolveTargetQuery(cross_target);
     return result;


### PR DESCRIPTION
With the Zig version `v0.14.0-dev.2563+af5e73172` building and running the project fails with the following error
```bash
/Users/juancarlosllh/Source/Zig-Playdate-Template/build.zig:62:8: error: no field or member function named 'setLinkerScriptPath' in 'Build.Step.Compile'
    elf.setLinkerScriptPath(b.path("link_map.ld"));
    ~~~^~~~~~~~~~~~~~~~~~~~
/Users/juancarlosllh/Source/zig-0.14.0-dev/lib/std/Build/Step/Compile.zig:1:1: note: struct declared here
const builtin = @import("builtin");
^~~~~
/Users/juancarlosllh/Source/Zig-Playdate-Template/build.zig:62:8: note: method invocation only supports up to one level of implicit pointer dereferencing
/Users/juancarlosllh/Source/Zig-Playdate-Template/build.zig:62:8: note: use '.*' to dereference pointer
referenced by:
    runBuild__anon_4797: /Users/juancarlosllh/Source/zig-0.14.0-dev/lib/std/Build.zig:2389:44
    main: /Users/juancarlosllh/Source/zig-0.14.0-dev/lib/compiler/build_runner.zig:339:29
    4 reference(s) hidden; use '-freference-trace=6' to see all references
/Users/juancarlosllh/Source/Zig-Playdate-Template/build.zig:129:43: error: no field named 'host' in struct 'Build'
        if (!force_use_cross_target and b.host.result.os.tag == cross_target.os_tag.?)
                                          ^~~~
/Users/juancarlosllh/Source/zig-0.14.0-dev/lib/std/Build.zig:1:1: note: struct declared here
const std = @import("std.zig");
^~~~~
```

These PR fixes those deprecation errors and now building and running should working again.

I could only test it on a M1 Mac OS and the simulator 